### PR TITLE
interest: declare DEFAULT_INTEREST_LIFETIME as milliseconds type

### DIFF
--- a/src/interest.hpp
+++ b/src/interest.hpp
@@ -36,7 +36,10 @@ namespace ndn {
 
 class Data;
 
-const time::seconds DEFAULT_INTEREST_LIFETIME = time::seconds(4);
+/** @var const unspecified_duration_type DEFAULT_INTEREST_LIFETIME;
+ *  @brief default value for InterestLifetime
+ */
+const time::milliseconds DEFAULT_INTEREST_LIFETIME = time::milliseconds(4000);
 
 /** @brief represents an Interest packet
  */


### PR DESCRIPTION
In public API, this constant is described as unspecified duration type.

refs #2130

Change-Id: Id8f8cbe2af78e5e8615c9c44d795937c169eb4c2
