### PR TITLE
Fix signing by identity (ECDSA)

### DIFF
--- a/src/security/key-chain.hpp
+++ b/src/security/key-chain.hpp
@@ -204,7 +204,7 @@ public:
    * @see generateRsaKeyPair, generateEcdsaKeyPair, generateRsaKeyPairAsDefault
    */
   Name
-  generateEcdsaKeyPairAsDefault(const Name& identityName, bool isKsk, uint32_t keySize = 256);
+  generateEcdsaKeyPairAsDefault(const Name& identityName, bool isKsk=false, uint32_t keySize = 256);
 
   /**
    * @brief prepare an unsigned identity certificate

--- a/src/security/key-chain.hpp
+++ b/src/security/key-chain.hpp
@@ -528,6 +528,9 @@ public:
     return m_pib->getDefaultKeyNameForIdentity(identityName);
   }
 
+  KeyParams
+  getDefaultKeyParamsForIdentity(const Name& identityName) const;
+
   Name
   getDefaultCertificateNameForKey(const Name& keyName) const
   {

--- a/tests/unit-tests/security/key-chain.t.cpp
+++ b/tests/unit-tests/security/key-chain.t.cpp
@@ -417,6 +417,20 @@ BOOST_AUTO_TEST_CASE(GeneralSigningInterface)
                                                                 interest5.getName()[-1].blockFromValue()))));
 }
 
+BOOST_AUTO_TEST_CASE(EcdsaSigningByIdentityNoCert)
+{
+  KeyChain keyChain;
+  Name ecdsaIdentity("/ndn/test/ecdsa");
+  Name ecdsaKeyName = keyChain.generateEcdsaKeyPairAsDefault(ecdsaIdentity,false,256);
+  Data ecdsaData("/ecdsaSignedData");
+  BOOST_CHECK_EQUAL(keyChain.getPublicKey(keyChain.getDefaultKeyNameForIdentity(ecdsaIdentity))->getKeyType(),
+		  KeyType::KEY_TYPE_ECDSA);
+  keyChain.signByIdentity(ecdsaData,ecdsaIdentity);
+  BOOST_CHECK_EQUAL(ecdsaData.getSignature().getType(),tlv::SignatureSha256WithEcdsa);
+  BOOST_CHECK_EQUAL(keyChain.getPublicKey(keyChain.getDefaultKeyNameForIdentity(ecdsaIdentity))->getKeyType(),
+		  KeyType::KEY_TYPE_ECDSA);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace tests

--- a/tools/ndnsec/cert-gen.hpp
+++ b/tools/ndnsec/cert-gen.hpp
@@ -211,7 +211,7 @@ ndnsec_cert_gen(int argc, char** argv)
       return 1;
     }
 
-  keyChain.createIdentity(signId);
+  keyChain.createIdentity(signId,keyChain.getDefaultKeyParamsForIdentity(signId));
   Name signingCertificateName = keyChain.getDefaultCertificateNameForIdentity(signId);
   keyChain.sign(*certificate,
                 security::SigningInfo(security::SigningInfo::SIGNER_TYPE_CERT,


### PR DESCRIPTION
- When signing by identity, if no certificate is available for the default key and its type does not corresponds to the DEFAULT_KEY_PARAMS a new pair of DEFAULT_KEY_PARAMS keys is created, set as default and used for signing. Solved by checking the type of key of the default key pair for the identity.

- Unit tests addressing the issue are also included.

- Added a default value (false) to 'isKsk' for 'KeyChain::generateEcdsaKeyPairAsDefault' 

