### PR TITLE
use only major version for soname

### DIFF
--- a/wscript
+++ b/wscript
@@ -185,7 +185,7 @@ def build(bld):
     if bld.env.enable_shared:
         bld(features=['pch', 'cxx', 'cxxshlib'],
             vnum=VERSION_BASE,
-            cnum=VERSION_BASE,
+            cnum=VERSION_BASE.split('.')[0],
             **libndn_cxx)
 
     if bld.env.enable_static:


### PR DESCRIPTION
hello NDN team, i sent this mail to ndn-lib last week, but it looks like it never reached there,
please tell me where is the best place to discuss this...

at Endlessm.com we're working on integrating NDN software in our next
release, and part of that works involves pushing software to upstream
Debian. For that we've been working on a few packages.

tl;dr: do we want to commit to bumping soname only when we actually have an
ABI break ?

one of them is the package for ndn-cxx or in debian terms libndn-cxx, the
current ppa packaging calls it just ndn-cxx, but that violates policy (libs
should have the soname in their name).

https://github.com/named-data/ppa-packaging/blob/master/ndn-cxx/debian/control

it also ships binaries in a single pack.

we created a new package for ndn-cxx that is cleaner in respect to Debian
Policy and packaging best practices, it creates an ndn-tools package (maybe
should be called ndn-utils to not conflict with the ndn-tools repo ?) uses a
tool we created: dh-waf to simplify greatly the packaging (and make it
multiarch ready). and finally, that's the purpose of this mail, ships a
patch to set soname to the major version

https://github.com/endlessm/ndn-cxx/blob/T13932-packaging/debian/control
https://github.com/endlessm/dh-waf
https://github.com/endlessm/ndn-cxx/blob/T13932-packaging/debian/patches/make-soname-be-the-major-version

without that patch, every change of version would require a new package
(i.e. libndn-cxx0.5.0 -> libndn-cxx0.5.1 -> libndn-cxx0.5.2...) while i
understand not tracking sonames makes it easier for dev, it makes it much
harder for integration in distros, so i'd like to find a place where it
works for all of us.

how can we find a common ground between not putting burden on dev and on
packaging ? whilst still making it possible to ship code in a distro ?

Signed-off-by: Niv Sardi <xaiki@evilgiggle.com>